### PR TITLE
updated DDP RateLimiter code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ DDPRateLimiter.addRule(
     clientAddress: null,
     name(name) {
       const methods = [ 'twoFactor.verifyCodeAndLogin', 'twoFactor.getAuthenticationCode' ]
-      return methods.indexOf(name) > -1
+      return methods.includes(name)
     },
     connectionId() {
       return true

--- a/README.md
+++ b/README.md
@@ -136,7 +136,15 @@ const timeInterval = 60;
 DDPRateLimiter.addRule(
   {
     type: 'method',
-    name: 'twoFactor.verifyCodeAndLogin',
+    userId: null,
+    clientAddress: null,
+    name(name) {
+      const methods = [ 'twoFactor.verifyCodeAndLogin', 'twoFactor.getAuthenticationCode' ]
+      return methods.indexOf(name) > -1
+    },
+    connectionId() {
+      return true
+    }
   },
   numberOfAttempts,
   timeInterval * 1000


### PR DESCRIPTION
The most critical improvement is connectionId field in the rule. It is required to set limit per connectionId instead of per app.