### PR TITLE
Feature: resend auth code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Simple two factor authentication for accounts-password.
   - [Client](https://github.com/dburles/meteor-two-factor#api-client)
     - [getAuthCode](https://github.com/dburles/meteor-two-factor#getauthcode)
     - [getNewAuthCode](https://github.com/dburles/meteor-two-factor#getnewauthcode)
+    - [resendAuthCode](https://github.com/dburles/meteor-two-factor#resendauthcode)
     - [verifyAndLogin](https://github.com/dburles/meteor-two-factor#verifyandlogin)
     - [isVerifying](https://github.com/dburles/meteor-two-factor#isverifying)
     - [abort](https://github.com/dburles/meteor-two-factor#abort)
@@ -181,6 +182,16 @@ getNewAuthCode([callback])
 ```
 
 Generates a new authentication code. Only functional while verifying.
+
+**callback** Optional callback. Called with no arguments on success, or with a single Error argument on failure.
+
+### resendAuthCode
+
+```
+resendAuthCode([callback])
+```
+
+Sends generated authentication code one more time. Only functional while verifying.
 
 **callback** Optional callback. Called with no arguments on success, or with a single Error argument on failure.
 

--- a/client.js
+++ b/client.js
@@ -56,6 +56,14 @@ const getNewAuthCode = cb => {
   Meteor.call('twoFactor.getAuthenticationCode', selector, password, callback);
 };
 
+const resendAuthCode = cb => {
+  const selector = getSelector(state.get('user'));
+  const password = state.get('password');
+  const callback = callbackHandler(cb);
+
+  Meteor.call('twoFactor.resendAuthenticationCode', selector, password, callback);
+};
+
 const verifyAndLogin = (code, cb) => {
   const selector = getSelector(state.get('user'));
 
@@ -95,6 +103,7 @@ const abort = cb => {
 
 twoFactor.getAuthCode = getAuthCode;
 twoFactor.getNewAuthCode = getNewAuthCode;
+twoFactor.resendAuthCode = resendAuthCode;
 twoFactor.verifyAndLogin = verifyAndLogin;
 twoFactor.isVerifying = isVerifying;
 twoFactor.abort = abort;

--- a/server.js
+++ b/server.js
@@ -69,6 +69,27 @@ Meteor.methods({
       },
     });
   },
+  'twoFactor.resendAuthenticationCode'(userQuery, password) {
+    check(userQuery, userQueryValidator);
+    check(password, passwordValidator);
+
+    const user = Accounts._findUserByQuery(userQuery);
+    if (!user) {
+      throw invalidLogin();
+    }
+
+    const checkPassword = Accounts._checkPassword(user, password);
+    if (checkPassword.error) {
+      throw invalidLogin();
+    }
+
+    const fieldName = getFieldName();
+    const code = user[fieldName];
+
+    if (typeof twoFactor.sendCode === 'function') {
+      twoFactor.sendCode(user, code);
+    }
+  },
   'twoFactor.verifyCodeAndLogin'(options) {
     check(options, {
       user: userQueryValidator,

--- a/server.js
+++ b/server.js
@@ -37,22 +37,26 @@ const getFieldName = () => {
   return twoFactor.options.fieldName || 'twoFactorCode';
 };
 
+const verifyUser = ({userQuery, password}) => {
+  const user = Accounts._findUserByQuery(userQuery);
+  if (!user) {
+    throw invalidLogin();
+  }
+
+  const checkPassword = Accounts._checkPassword(user, password);
+  if (checkPassword.error) {
+    throw invalidLogin();
+  }
+
+  return user;
+};
+
 Meteor.methods({
   'twoFactor.getAuthenticationCode'(userQuery, password) {
     check(userQuery, userQueryValidator);
     check(password, passwordValidator);
 
-    const fieldName = getFieldName();
-
-    const user = Accounts._findUserByQuery(userQuery);
-    if (!user) {
-      throw invalidLogin();
-    }
-
-    const checkPassword = Accounts._checkPassword(user, password);
-    if (checkPassword.error) {
-      throw invalidLogin();
-    }
+    const user = verifyUser({userQuery, password});
 
     const code =
       typeof twoFactor.generateCode === 'function'
@@ -62,6 +66,8 @@ Meteor.methods({
     if (typeof twoFactor.sendCode === 'function') {
       twoFactor.sendCode(user, code);
     }
+
+    const fieldName = getFieldName();
 
     Meteor.users.update(user._id, {
       $set: {
@@ -73,15 +79,7 @@ Meteor.methods({
     check(userQuery, userQueryValidator);
     check(password, passwordValidator);
 
-    const user = Accounts._findUserByQuery(userQuery);
-    if (!user) {
-      throw invalidLogin();
-    }
-
-    const checkPassword = Accounts._checkPassword(user, password);
-    if (checkPassword.error) {
-      throw invalidLogin();
-    }
+    const user = verifyUser({userQuery, password});
 
     const fieldName = getFieldName();
     const code = user[fieldName];
@@ -99,15 +97,10 @@ Meteor.methods({
 
     const fieldName = getFieldName();
 
-    const user = Accounts._findUserByQuery(options.user);
-    if (!user) {
-      throw invalidLogin();
-    }
-
-    const checkPassword = Accounts._checkPassword(user, options.password);
-    if (checkPassword.error) {
-      throw invalidLogin();
-    }
+    const user = verifyUser({
+      userQuery: options.user,
+      password: options.password
+    });
 
     if (options.code !== user[fieldName]) {
       throw new Meteor.Error(403, 'Invalid code');
@@ -128,17 +121,8 @@ Meteor.methods({
     check(userQuery, userQueryValidator);
     check(password, passwordValidator);
 
+    const user = verifyUser({userQuery, password})
     const fieldName = getFieldName();
-
-    const user = Accounts._findUserByQuery(userQuery);
-    if (!user) {
-      throw invalidLogin();
-    }
-
-    const checkPassword = Accounts._checkPassword(user, password);
-    if (checkPassword.error) {
-      throw invalidLogin();
-    }
 
     Meteor.users.update(user._id, {
       $unset: {


### PR DESCRIPTION
Problem.
If there is a delay with code delivery user requests new code which replaces the old one. When user tries to enter first code, login attempt fails.

Solution: provide option to send the same code again.

Changes:

- added new client side API method resendAuthCode
- added meteor method  accordingly
- refactored server methods